### PR TITLE
Add link update method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2571,6 +2571,19 @@ export namespace JUHUU {
       export type Response = JUHUU.Link.Object[];
     }
 
+    export namespace Update {
+      export type Params = {
+        linkId: string;
+        name?: string;
+      };
+
+      export type Options = JUHUU.RequestOptions;
+
+      export type Response = {
+        link: JUHUU.Link.Object;
+      };
+    }
+
     export namespace Delete {
       export type Params = {
         linkId: string;

--- a/src/links/links.service.ts
+++ b/src/links/links.service.ts
@@ -88,6 +88,23 @@ export default class LinkService extends Service {
     );
   }
 
+  async update(
+    LinkUpdateParams: JUHUU.Link.Update.Params,
+    LinkUpdateOptions?: JUHUU.Link.Update.Options
+  ): Promise<JUHUU.HttpResponse<JUHUU.Link.Update.Response>> {
+    return await super.sendRequest<JUHUU.Link.Update.Response>(
+      {
+        method: "PATCH",
+        url: "links/" + LinkUpdateParams.linkId,
+        body: {
+          name: LinkUpdateParams.name,
+        },
+        authenticationNotOptional: true,
+      },
+      LinkUpdateOptions
+    );
+  }
+
   async delete(
     LinkDeleteParams: JUHUU.Link.Delete.Params,
     LinkDeleteOptions?: JUHUU.Link.Delete.Options


### PR DESCRIPTION
## Summary
- add update method to `LinkService`
- define `JUHUU.Link.Update` types
- remove deprecated `fiveLetterQr` field from link update

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685950bb488c8330aa0686ea890fb43e