### PR TITLE
Add payout create, property delete, sim update

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1924,6 +1924,16 @@ export namespace JUHUU {
         property: JUHUU.Property.Object;
       };
     }
+
+    export namespace Delete {
+      export type Params = {
+        propertyId: string;
+      };
+
+      export type Options = JUHUU.RequestOptions;
+
+      export type Response = JUHUU.Property.Object;
+    }
   }
 
   export namespace Point {
@@ -2014,6 +2024,21 @@ export namespace JUHUU {
       creditNotePdfId: string;
       stripeConnectedAccountId: string;
     };
+
+    export namespace Create {
+      export type Params = {
+        propertyId: string;
+        fromDate: number;
+        toDate: number;
+        statementDescription: string;
+      };
+
+      export type Options = JUHUU.RequestOptions;
+
+      export type Response = {
+        payout: JUHUU.Payout.Object;
+      };
+    }
 
     export namespace Retrieve {
       export type Params = {
@@ -3582,6 +3607,21 @@ export namespace JUHUU {
       export type Options = JUHUU.RequestOptions;
 
       export type Response = JUHUU.Sim.Object[];
+    }
+
+    export namespace Update {
+      export type Params = {
+        simId: string;
+        name?: string;
+        description?: string | null;
+        dataQuotaThresholdPercentage?: number | null;
+      };
+
+      export type Options = JUHUU.RequestOptions;
+
+      export type Response = {
+        sim: JUHUU.Sim.Object;
+      };
     }
 
     export namespace UpdateFromProvider {

--- a/src/payouts/payouts.service.ts
+++ b/src/payouts/payouts.service.ts
@@ -6,6 +6,26 @@ export default class PayoutsService extends Service {
     super(config);
   }
 
+  async create(
+    PayoutCreateParams: JUHUU.Payout.Create.Params,
+    PayoutCreateOptions?: JUHUU.Payout.Create.Options
+  ): Promise<JUHUU.HttpResponse<JUHUU.Payout.Create.Response>> {
+    return await super.sendRequest<JUHUU.Payout.Create.Response>(
+      {
+        method: "POST",
+        url: "payouts",
+        body: {
+          propertyId: PayoutCreateParams.propertyId,
+          fromDate: PayoutCreateParams.fromDate,
+          toDate: PayoutCreateParams.toDate,
+          statementDescription: PayoutCreateParams.statementDescription,
+        },
+        authenticationNotOptional: true,
+      },
+      PayoutCreateOptions
+    );
+  }
+
   async retrieve(
     PayoutRetrieveParams: JUHUU.Payout.Retrieve.Params,
     PayoutRetrieveOptions?: JUHUU.Payout.Retrieve.Options

--- a/src/properties/properties.service.ts
+++ b/src/properties/properties.service.ts
@@ -218,4 +218,19 @@ export default class PropertiesService extends Service {
       PropertyAcceptLatestAgreementOptions
     );
   }
+
+  async delete(
+    PropertyDeleteParams: JUHUU.Property.Delete.Params,
+    PropertyDeleteOptions?: JUHUU.Property.Delete.Options
+  ): Promise<JUHUU.HttpResponse<JUHUU.Property.Delete.Response>> {
+    return await super.sendRequest<JUHUU.Property.Delete.Response>(
+      {
+        method: "DELETE",
+        url: "properties/" + PropertyDeleteParams.propertyId,
+        authenticationNotOptional: true,
+        body: undefined,
+      },
+      PropertyDeleteOptions
+    );
+  }
 }

--- a/src/sims/sims.service.ts
+++ b/src/sims/sims.service.ts
@@ -61,6 +61,26 @@ export default class SimsService extends Service {
     );
   }
 
+  async update(
+    SimUpdateParams: JUHUU.Sim.Update.Params,
+    SimUpdateOptions?: JUHUU.Sim.Update.Options
+  ): Promise<JUHUU.HttpResponse<JUHUU.Sim.Update.Response>> {
+    return await super.sendRequest<JUHUU.Sim.Update.Response>(
+      {
+        method: "PATCH",
+        url: "sims/" + SimUpdateParams.simId,
+        body: {
+          name: SimUpdateParams.name,
+          description: SimUpdateParams.description,
+          dataQuotaThresholdPercentage:
+            SimUpdateParams.dataQuotaThresholdPercentage,
+        },
+        authenticationNotOptional: true,
+      },
+      SimUpdateOptions
+    );
+  }
+
   async updateFromProvider(
     SimUpdateFromProviderParams: JUHUU.Sim.UpdateFromProvider.Params,
     SimUpdateFromProviderOptions?: JUHUU.Sim.UpdateFromProvider.Options


### PR DESCRIPTION
## Summary
- add method for creating payouts
- support deleting properties
- add sim update method
- define types for new methods

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68599973ea5c83308ba8bf545309f91d