### PR TITLE
Add flows service and types

### DIFF
--- a/src/flows/flows.service.ts
+++ b/src/flows/flows.service.ts
@@ -1,0 +1,103 @@
+import { JUHUU } from "..";
+import Service from "../index.service";
+
+export default class FlowsService extends Service {
+  constructor(config: JUHUU.SetupConfig) {
+    super(config);
+  }
+
+  async create(
+    FlowCreateParams: JUHUU.Flow.Create.Params,
+    FlowCreateOptions?: JUHUU.Flow.Create.Options
+  ): Promise<JUHUU.HttpResponse<JUHUU.Flow.Create.Response>> {
+    return await super.sendRequest<JUHUU.Flow.Create.Response>(
+      {
+        method: "POST",
+        url: "flows",
+        body: {
+          name: FlowCreateParams.name,
+          startBlock: FlowCreateParams.startBlock,
+          blocks: FlowCreateParams.blocks,
+          edges: FlowCreateParams.edges,
+        },
+        authenticationNotOptional: true,
+      },
+      FlowCreateOptions
+    );
+  }
+
+  async list(
+    FlowListParams: JUHUU.Flow.List.Params,
+    FlowListOptions?: JUHUU.Flow.List.Options
+  ): Promise<JUHUU.HttpResponse<JUHUU.Flow.List.Response>> {
+    const queryArray: string[] = [];
+
+    if (FlowListOptions?.limit !== undefined) {
+      queryArray.push("limit=" + FlowListOptions.limit);
+    }
+
+    if (FlowListOptions?.skip !== undefined) {
+      queryArray.push("skip=" + FlowListOptions.skip);
+    }
+
+    return await super.sendRequest<JUHUU.Flow.List.Response>(
+      {
+        method: "GET",
+        url: "flows?" + queryArray.join("&"),
+        body: undefined,
+        authenticationNotOptional: false,
+      },
+      FlowListOptions
+    );
+  }
+
+  async retrieve(
+    FlowRetrieveParams: JUHUU.Flow.Retrieve.Params,
+    FlowRetrieveOptions?: JUHUU.Flow.Retrieve.Options
+  ): Promise<JUHUU.HttpResponse<JUHUU.Flow.Retrieve.Response>> {
+    return await super.sendRequest<JUHUU.Flow.Retrieve.Response>(
+      {
+        method: "GET",
+        url: "flows/" + FlowRetrieveParams.flowId,
+        body: undefined,
+        authenticationNotOptional: false,
+      },
+      FlowRetrieveOptions
+    );
+  }
+
+  async update(
+    FlowUpdateParams: JUHUU.Flow.Update.Params,
+    FlowUpdateOptions?: JUHUU.Flow.Update.Options
+  ): Promise<JUHUU.HttpResponse<JUHUU.Flow.Update.Response>> {
+    return await super.sendRequest<JUHUU.Flow.Update.Response>(
+      {
+        method: "PATCH",
+        url: "flows/" + FlowUpdateParams.flowId,
+        body: {
+          name: FlowUpdateParams.name,
+          startBlock: FlowUpdateParams.startBlock,
+          blocks: FlowUpdateParams.blocks,
+          edges: FlowUpdateParams.edges,
+        },
+        authenticationNotOptional: true,
+      },
+      FlowUpdateOptions
+    );
+  }
+
+  async delete(
+    FlowDeleteParams: JUHUU.Flow.Delete.Params,
+    FlowDeleteOptions?: JUHUU.Flow.Delete.Options
+  ): Promise<JUHUU.HttpResponse<JUHUU.Flow.Delete.Response>> {
+    return await super.sendRequest<JUHUU.Flow.Delete.Response>(
+      {
+        method: "DELETE",
+        url: "flows/" + FlowDeleteParams.flowId,
+        authenticationNotOptional: true,
+        body: undefined,
+      },
+      FlowDeleteOptions
+    );
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,8 @@ import {
   UserGroup,
   Utilization,
   VisualPriority,
+  FlowBlock,
+  FlowEdge,
 } from "./types/types";
 import SettingsService from "./settings/settings.service";
 import AccountingAreasService from "./accountingAreas/accountingAreas.service";
@@ -78,6 +80,7 @@ import IncidentTemplatesService from "./incidentTemplates/incidentTemplates.serv
 import IncidentsService from "./incidents/incidents.service";
 import ParameterAnomalyGroupsService from "./parameterAnomalyGroups/parameterAnomalyGroups.service";
 import ParameterAnomalyGroupTrackersService from "./parameterAnomalyGroupTrackers/parameterAnomalyGroupTrackers.service";
+import FlowsService from "./flows/flows.service";
 
 export * from "./types/types";
 
@@ -119,6 +122,7 @@ export class Juhuu {
     this.parameterAnomalyGroups = new ParameterAnomalyGroupsService(config);
     this.parameterAnomalyGroupTrackers =
       new ParameterAnomalyGroupTrackersService(config);
+    this.flows = new FlowsService(config);
   }
 
   /**
@@ -158,6 +162,7 @@ export class Juhuu {
   readonly incidents: IncidentsService;
   readonly parameterAnomalyGroups: ParameterAnomalyGroupsService;
   readonly parameterAnomalyGroupTrackers: ParameterAnomalyGroupTrackersService;
+  readonly flows: FlowsService;
 }
 
 export namespace JUHUU {
@@ -3483,6 +3488,87 @@ export namespace JUHUU {
         parameterHistoryArray: JUHUU.ParameterHistory.Object[];
         count: number;
         hasMore: boolean;
+      };
+    }
+  }
+
+  export namespace Flow {
+    export type Object = {
+      id: string;
+      readonly object: "flow";
+      name: string;
+      startBlock: FlowBlock;
+      blocks: FlowBlock[];
+      edges: FlowEdge[];
+    };
+
+    export namespace Create {
+      export type Params = {
+        name: string;
+        startBlock: FlowBlock;
+        blocks: FlowBlock[];
+        edges: FlowEdge[];
+      };
+
+      export type Options = JUHUU.RequestOptions;
+
+      export type Response = {
+        flow: JUHUU.Flow.Object;
+      };
+    }
+
+    export namespace Retrieve {
+      export type Params = {
+        flowId: string;
+      };
+
+      export type Options = JUHUU.RequestOptions;
+
+      export type Response = {
+        flow: JUHUU.Flow.Object;
+      };
+    }
+
+    export namespace List {
+      export type Params = {};
+
+      export type Options = {
+        limit?: number;
+        skip?: number;
+      } & JUHUU.RequestOptions;
+
+      export type Response = {
+        flowArray: JUHUU.Flow.Object[];
+        count: number;
+        hasMore: boolean;
+      };
+    }
+
+    export namespace Update {
+      export type Params = {
+        flowId: string;
+        name?: string;
+        startBlock?: FlowBlock;
+        blocks?: FlowBlock[];
+        edges?: FlowEdge[];
+      };
+
+      export type Options = JUHUU.RequestOptions;
+
+      export type Response = {
+        flow: JUHUU.Flow.Object;
+      };
+    }
+
+    export namespace Delete {
+      export type Params = {
+        flowId: string;
+      };
+
+      export type Options = JUHUU.RequestOptions;
+
+      export type Response = {
+        flow: JUHUU.Flow.Object;
       };
     }
   }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1188,3 +1188,16 @@ export interface LocaleString {
   cs?: string;
   et?: string;
 }
+
+export type FlowBlock = {
+  id: string;
+  type: string;
+  in: { [key: string]: string };
+  out: { [key: string]: string };
+};
+
+export type FlowEdge = {
+  id: string;
+  from: { blockId: string; output: string };
+  to: { blockId: string; input: string };
+};


### PR DESCRIPTION
## Summary
- implement `FlowsService` for CRUD endpoints
- expose `flows` service in `Juhuu` SDK
- define `FlowBlock` and `FlowEdge` types
- add `Flow` namespace declarations

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685c1bdca99c8330ab5af4e42ba474f0