### PR TITLE
Add MqttTopic service and namespace

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,7 @@ import ParameterAnomalyGroupsService from "./parameterAnomalyGroups/parameterAno
 import ParameterAnomalyGroupTrackersService from "./parameterAnomalyGroupTrackers/parameterAnomalyGroupTrackers.service";
 import EmzService from "./emz/emz.service";
 import FlowsService from "./flows/flows.service";
+import MqttTopicsService from "./mqttTopics/mqttTopics.service";
 
 export * from "./types/types";
 
@@ -123,6 +124,7 @@ export class Juhuu {
       new ParameterAnomalyGroupTrackersService(config);
     this.emz = new EmzService(config);
     this.flows = new FlowsService(config);
+    this.mqttTopics = new MqttTopicsService(config);
   }
 
   /**
@@ -162,6 +164,7 @@ export class Juhuu {
   readonly parameterAnomalyGroupTrackers: ParameterAnomalyGroupTrackersService;
   readonly emz: EmzService;
   readonly flows: FlowsService;
+  readonly mqttTopics: MqttTopicsService;
 }
 
 export namespace JUHUU {
@@ -3664,6 +3667,84 @@ export namespace JUHUU {
       export type Options = JUHUU.RequestOptions;
 
       export type Response = JUHUU.Sim.Object;
+    }
+  }
+
+  export namespace MqttTopic {
+    export type Object = {
+      id: string;
+      readonly object: "mqttTopic";
+      name: string;
+      propertyId: string;
+      chatId: string | null;
+    };
+
+    export namespace Create {
+      export type Params = {
+        propertyId: string;
+        name?: string;
+        chatId?: string | null;
+      };
+
+      export type Options = JUHUU.RequestOptions;
+
+      export type Response = {
+        mqttTopic: JUHUU.MqttTopic.Object;
+      };
+    }
+
+    export namespace Retrieve {
+      export type Params = {
+        mqttTopicId: string;
+      };
+
+      export type Options = JUHUU.RequestOptions;
+
+      export type Response = {
+        mqttTopic: JUHUU.MqttTopic.Object;
+      };
+    }
+
+    export namespace List {
+      export type Params = {
+        propertyId?: string;
+        chatId?: string;
+      };
+
+      export type Options = {
+        limit?: number;
+        skip?: number;
+      } & JUHUU.RequestOptions;
+
+      export type Response = {
+        mqttTopicArray: JUHUU.MqttTopic.Object[];
+        count: number;
+        hasMore: boolean;
+      };
+    }
+
+    export namespace Update {
+      export type Params = {
+        mqttTopicId: string;
+        name?: string;
+        chatId?: string | null;
+      };
+
+      export type Options = JUHUU.RequestOptions;
+
+      export type Response = {
+        mqttTopic: JUHUU.MqttTopic.Object;
+      };
+    }
+
+    export namespace Delete {
+      export type Params = {
+        mqttTopicId: string;
+      };
+
+      export type Options = JUHUU.RequestOptions;
+
+      export type Response = JUHUU.MqttTopic.Object;
     }
   }
 

--- a/src/mqttTopics/mqttTopics.service.ts
+++ b/src/mqttTopics/mqttTopics.service.ts
@@ -1,0 +1,110 @@
+import { JUHUU } from "..";
+import Service from "../index.service";
+
+export default class MqttTopicsService extends Service {
+  constructor(config: JUHUU.SetupConfig) {
+    super(config);
+  }
+
+  async create(
+    params: JUHUU.MqttTopic.Create.Params,
+    options?: JUHUU.MqttTopic.Create.Options
+  ): Promise<JUHUU.HttpResponse<JUHUU.MqttTopic.Create.Response>> {
+    return await super.sendRequest<JUHUU.MqttTopic.Create.Response>(
+      {
+        method: "POST",
+        url: "mqttTopics",
+        body: {
+          propertyId: params.propertyId,
+          name: params.name,
+          chatId: params.chatId,
+        },
+        authenticationNotOptional: true,
+      },
+      options
+    );
+  }
+
+  async list(
+    params: JUHUU.MqttTopic.List.Params,
+    options?: JUHUU.MqttTopic.List.Options
+  ): Promise<JUHUU.HttpResponse<JUHUU.MqttTopic.List.Response>> {
+    const queryArray: string[] = [];
+
+    if (params?.propertyId !== undefined) {
+      queryArray.push("propertyId=" + params.propertyId);
+    }
+
+    if (params?.chatId !== undefined) {
+      queryArray.push("chatId=" + params.chatId);
+    }
+
+    if (options?.limit !== undefined) {
+      queryArray.push("limit=" + options.limit);
+    }
+
+    if (options?.skip !== undefined) {
+      queryArray.push("skip=" + options.skip);
+    }
+
+    return await super.sendRequest<JUHUU.MqttTopic.List.Response>(
+      {
+        method: "GET",
+        url: "mqttTopics?" + queryArray.join("&"),
+        body: undefined,
+        authenticationNotOptional: false,
+      },
+      options
+    );
+  }
+
+  async retrieve(
+    params: JUHUU.MqttTopic.Retrieve.Params,
+    options?: JUHUU.MqttTopic.Retrieve.Options
+  ): Promise<JUHUU.HttpResponse<JUHUU.MqttTopic.Retrieve.Response>> {
+    const queryArray: string[] = [];
+
+    return await super.sendRequest<JUHUU.MqttTopic.Retrieve.Response>(
+      {
+        method: "GET",
+        url: "mqttTopics/" + params.mqttTopicId + "?" + queryArray.join("&"),
+        body: undefined,
+        authenticationNotOptional: false,
+      },
+      options
+    );
+  }
+
+  async update(
+    params: JUHUU.MqttTopic.Update.Params,
+    options?: JUHUU.MqttTopic.Update.Options
+  ): Promise<JUHUU.HttpResponse<JUHUU.MqttTopic.Update.Response>> {
+    return await super.sendRequest<JUHUU.MqttTopic.Update.Response>(
+      {
+        method: "PATCH",
+        url: "mqttTopics/" + params.mqttTopicId,
+        body: {
+          name: params.name,
+          chatId: params.chatId,
+        },
+        authenticationNotOptional: true,
+      },
+      options
+    );
+  }
+
+  async delete(
+    params: JUHUU.MqttTopic.Delete.Params,
+    options?: JUHUU.MqttTopic.Delete.Options
+  ): Promise<JUHUU.HttpResponse<JUHUU.MqttTopic.Delete.Response>> {
+    return await super.sendRequest<JUHUU.MqttTopic.Delete.Response>(
+      {
+        method: "DELETE",
+        url: "mqttTopics/" + params.mqttTopicId,
+        authenticationNotOptional: true,
+        body: undefined,
+      },
+      options
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add MqttTopicsService to interact with mqttTopics endpoints
- instantiate the service inside `Juhuu` class
- expose new `mqttTopics` property
- define JUHUU.MqttTopic namespace and its API request/response types

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68716f4459a8832cb12a18230fdfaaf6