### PR TITLE
Add FlowTrace service

### DIFF
--- a/src/flowTraces/flowTraces.service.ts
+++ b/src/flowTraces/flowTraces.service.ts
@@ -1,0 +1,56 @@
+import { JUHUU } from "..";
+import Service from "../index.service";
+
+export default class FlowTracesService extends Service {
+  constructor(config: JUHUU.SetupConfig) {
+    super(config);
+  }
+
+  async list(
+    FlowTraceListParams: JUHUU.FlowTrace.List.Params,
+    FlowTraceListOptions?: JUHUU.FlowTrace.List.Options
+  ): Promise<JUHUU.HttpResponse<JUHUU.FlowTrace.List.Response>> {
+    const queryArray: string[] = [];
+
+    if (FlowTraceListParams?.propertyId !== undefined) {
+      queryArray.push("propertyId=" + FlowTraceListParams.propertyId);
+    }
+
+    if (FlowTraceListParams?.flowId !== undefined) {
+      queryArray.push("flowId=" + FlowTraceListParams.flowId);
+    }
+
+    if (FlowTraceListOptions?.limit !== undefined) {
+      queryArray.push("limit=" + FlowTraceListOptions.limit);
+    }
+
+    if (FlowTraceListOptions?.skip !== undefined) {
+      queryArray.push("skip=" + FlowTraceListOptions.skip);
+    }
+
+    return await super.sendRequest<JUHUU.FlowTrace.List.Response>(
+      {
+        method: "GET",
+        url: "flowTraces?" + queryArray.join("&"),
+        body: undefined,
+        authenticationNotOptional: false,
+      },
+      FlowTraceListOptions
+    );
+  }
+
+  async retrieve(
+    FlowTraceRetrieveParams: JUHUU.FlowTrace.Retrieve.Params,
+    FlowTraceRetrieveOptions?: JUHUU.FlowTrace.Retrieve.Options
+  ): Promise<JUHUU.HttpResponse<JUHUU.FlowTrace.Retrieve.Response>> {
+    return await super.sendRequest<JUHUU.FlowTrace.Retrieve.Response>(
+      {
+        method: "GET",
+        url: "flowTraces/" + FlowTraceRetrieveParams.flowTraceId,
+        body: undefined,
+        authenticationNotOptional: false,
+      },
+      FlowTraceRetrieveOptions
+    );
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,7 @@ import ParameterAnomalyGroupsService from "./parameterAnomalyGroups/parameterAno
 import ParameterAnomalyGroupTrackersService from "./parameterAnomalyGroupTrackers/parameterAnomalyGroupTrackers.service";
 import EmzService from "./emz/emz.service";
 import FlowsService from "./flows/flows.service";
+import FlowTracesService from "./flowTraces/flowTraces.service";
 import MqttTopicsService from "./mqttTopics/mqttTopics.service";
 
 export * from "./types/types";
@@ -124,6 +125,7 @@ export class Juhuu {
       new ParameterAnomalyGroupTrackersService(config);
     this.emz = new EmzService(config);
     this.flows = new FlowsService(config);
+    this.flowTraces = new FlowTracesService(config);
     this.mqttTopics = new MqttTopicsService(config);
   }
 
@@ -164,6 +166,7 @@ export class Juhuu {
   readonly parameterAnomalyGroupTrackers: ParameterAnomalyGroupTrackersService;
   readonly emz: EmzService;
   readonly flows: FlowsService;
+  readonly flowTraces: FlowTracesService;
   readonly mqttTopics: MqttTopicsService;
 }
 
@@ -3504,6 +3507,52 @@ export namespace JUHUU {
         flow: JUHUU.Flow.Object;
 
         // todo: add result
+      };
+    }
+  }
+
+  export namespace FlowTrace {
+    export type Object = {
+      id: string;
+      readonly object: "flowTrace";
+      startAt: Date;
+      endAt: Date;
+      input: Record<string, any>;
+      output: Record<string, any>;
+      flowId: string;
+      propertyId: string;
+      logArray: string[];
+      error: string | null;
+      successful: boolean;
+    };
+
+    export namespace Retrieve {
+      export type Params = {
+        flowTraceId: string;
+      };
+
+      export type Options = JUHUU.RequestOptions;
+
+      export type Response = {
+        flowTrace: JUHUU.FlowTrace.Object;
+      };
+    }
+
+    export namespace List {
+      export type Params = {
+        propertyId?: string;
+        flowId?: string;
+      };
+
+      export type Options = {
+        skip?: number;
+        limit?: number;
+      } & JUHUU.RequestOptions;
+
+      export type Response = {
+        flowTraceArray: JUHUU.FlowTrace.Object[];
+        count: number;
+        hasMore: boolean;
       };
     }
   }


### PR DESCRIPTION
## Summary
- add FlowTracesService for listing and retrieving flow traces
- extend JUHUU types with FlowTrace namespace
- expose new service from main Juhuu class

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6874a860c0f4832c9a39f965e3510d7a