### PR TITLE
Add websockets service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@juhuu/sdk-ts",
-  "version": "1.2.46",
+  "version": "1.2.237",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@juhuu/sdk-ts",
-      "version": "1.2.46",
+      "version": "1.2.237",
       "license": "ISC",
       "dependencies": {
+        "@types/node": "^24.1.0",
         "socket.io-client": "^4.7.5"
       },
       "devDependencies": {
@@ -712,6 +713,15 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
       "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
     },
     "node_modules/ansi-regex": {
       "version": "6.0.1",
@@ -1964,6 +1974,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "license": "MIT"
     },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
+    "@types/node": "^24.1.0",
     "socket.io-client": "^4.7.5"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import LocationsService from "./locations/locations.service";
 import TermsService from "./terms/terms.service";
 import TariffsService from "./tariffs/tariffs.service";
 import ProductService from "./products/products.service";
+import WebsocketsService from "./websockets/websockets.service";
 import {
   AccessControlListElement,
   Address,
@@ -103,6 +104,7 @@ export class Juhuu {
     this.terms = new TermsService(config);
     this.tariffs = new TariffsService(config);
     this.products = new ProductService(config);
+    this.websockets = new WebsocketsService(config);
     this.settings = new SettingsService(config);
     this.accountingAreas = new AccountingAreasService(config);
     this.payouts = new PayoutsService(config);
@@ -146,6 +148,7 @@ export class Juhuu {
   readonly terms: TermsService;
   readonly tariffs: TariffsService;
   readonly products: ProductService;
+  readonly websockets: WebsocketsService;
   readonly settings: SettingsService;
   readonly accountingAreas: AccountingAreasService;
   readonly payouts: PayoutsService;
@@ -3900,5 +3903,69 @@ export namespace JUHUU {
 
       export type Response = JUHUU.ConnectorMessage.Object[];
     }
+  }
+
+  export namespace Websocket {
+    export namespace Connect {
+      export type Params = {};
+
+      export type Options = JUHUU.RequestOptions;
+
+      export type Response = {
+        subscribe: (rooms: string[]) => void;
+        unsubscribe: (rooms: string[]) => void;
+        subscribeQuery: (
+          payload: JUHUU.Websocket.SubscribeQuery.Params
+        ) => void;
+        unsubscribeQuery: (
+          payload: JUHUU.Websocket.UnsubscribeQuery.Params
+        ) => void;
+        rpc: (
+          payload: JUHUU.Websocket.Rpc.Params
+        ) => Promise<JUHUU.Websocket.Rpc.Response>;
+        onQueryUpdate: (
+          callback: (message: JUHUU.Websocket.QueryUpdate) => void
+        ) => void;
+        close: () => void;
+      };
+    }
+
+    export namespace SubscribeQuery {
+      export type Params = {
+        subId: string;
+        method: "GET";
+        path: string;
+        query?: Record<string, unknown>;
+      };
+    }
+
+    export namespace UnsubscribeQuery {
+      export type Params = {
+        subId: string;
+      };
+    }
+
+    export namespace Rpc {
+      export type Params = {
+        id: string;
+        method: "GET" | "POST" | "PATCH" | "DELETE";
+        path: string;
+        query?: Record<string, unknown>;
+        body?: unknown;
+        headers?: Record<string, unknown>;
+      };
+
+      export type Response = {
+        id: string;
+        status: number;
+        data?: unknown;
+        error?: unknown;
+      };
+    }
+
+    export type QueryUpdate = {
+      subId: string;
+      data: unknown;
+    };
   }
 }

--- a/src/websockets/websockets.service.ts
+++ b/src/websockets/websockets.service.ts
@@ -1,0 +1,62 @@
+import { JUHUU } from "..";
+import Service from "../index.service";
+
+export default class WebsocketsService extends Service {
+  constructor(config: JUHUU.SetupConfig) {
+    super(config);
+  }
+
+  connect(
+    WebsocketConnectOptions?: JUHUU.Websocket.Connect.Options
+  ): JUHUU.Websocket.Connect.Response {
+    const socket = super.connectToWebsocket({ url: "websocket" });
+
+    const pendingRpcResponses: Map<
+      string,
+      (value: JUHUU.Websocket.Rpc.Response) => void
+    > = new Map();
+
+    socket.on("rpc.response", (message: JUHUU.Websocket.Rpc.Response) => {
+      const resolver = pendingRpcResponses.get(message.id);
+      if (resolver !== undefined) {
+        resolver(message);
+        pendingRpcResponses.delete(message.id);
+      }
+    });
+
+    const onQueryUpdate = (
+      callback: (message: JUHUU.Websocket.QueryUpdate) => void
+    ) => {
+      socket.on("query.update", (message: JUHUU.Websocket.QueryUpdate) => {
+        callback(message);
+      });
+    };
+
+    return {
+      subscribe: (rooms: string[]) => {
+        socket.emit("subscribe", { rooms });
+      },
+      unsubscribe: (rooms: string[]) => {
+        socket.emit("unsubscribe", { rooms });
+      },
+      subscribeQuery: (payload: JUHUU.Websocket.SubscribeQuery.Params) => {
+        socket.emit("subscribeQuery", payload);
+      },
+      unsubscribeQuery: (payload: JUHUU.Websocket.UnsubscribeQuery.Params) => {
+        socket.emit("unsubscribeQuery", payload);
+      },
+      rpc: async (
+        payload: JUHUU.Websocket.Rpc.Params
+      ): Promise<JUHUU.Websocket.Rpc.Response> => {
+        return await new Promise((resolve) => {
+          pendingRpcResponses.set(payload.id, resolve);
+          socket.emit("rpc", payload);
+        });
+      },
+      onQueryUpdate,
+      close: () => {
+        socket.close();
+      },
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- implement `WebsocketsService` handling generic websocket features
- add service to `Juhuu` client
- define websocket types
- include @types/node for compilation

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_b_6884f4d28e60832c8d868b94f205ec8c